### PR TITLE
Unsafe struct check is too greedy

### DIFF
--- a/lib/check/warning/unsafe_struct.ex
+++ b/lib/check/warning/unsafe_struct.ex
@@ -18,7 +18,7 @@ defmodule CivilCredo.Check.Warning.UnsafeStruct do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  defp traverse( { :struct, meta , _args } = ast, issues, issue_meta ) do
+  defp traverse( { :struct, meta , args } = ast, issues, issue_meta ) when not is_nil(args) do
     {ast, issues_for_call(meta, issues, issue_meta)}
   end
 

--- a/lib/check/warning/unsafe_struct.ex
+++ b/lib/check/warning/unsafe_struct.ex
@@ -7,7 +7,7 @@ defmodule CivilCredo.Check.Warning.UnsafeStruct do
   the preferred form.
   """
 
-  @explanation [ check: @moduledoc ]
+  @explanation [check: @moduledoc]
 
   use Credo.Check, base_priority: :high, category: :warning, exit_status: 2
 
@@ -18,10 +18,27 @@ defmodule CivilCredo.Check.Warning.UnsafeStruct do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  defp traverse( { :struct, meta , args } = ast, issues, issue_meta ) when not is_nil(args) do
+  # Exclude 'struct' as function param or local
+  defp traverse({:struct, _meta, args} = ast, issues, _issue_meta) when is_nil(args) do
+    {ast, issues}
+  end
+
+  # Exclude `Ecto.Query.struct(source, fields)`
+  defp traverse(
+         {:struct, _meta, [_arg1, [arg2_head | _arg2_tail] = _arg2]} = ast,
+         issues,
+         _issue_meta
+       )
+       when is_atom(arg2_head) do
+    {ast, issues}
+  end
+
+  # Include Kernel.struct/2
+  defp traverse({:struct, meta, _args} = ast, issues, issue_meta) do
     {ast, issues_for_call(meta, issues, issue_meta)}
   end
 
+  # Exclude everything else
   defp traverse(ast, issues, _issue_meta) do
     {ast, issues}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CivilCredo.MixProject do
   def project do
     [
       app: :civil_credo,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/check/warning/unsafe_struct_test.exs
+++ b/test/check/warning/unsafe_struct_test.exs
@@ -18,7 +18,8 @@ defmodule CivilCredo.Check.Warning.UnsafeStructTest do
       string
       |> to_source_file
       |> assert_issue(@described_check, fn issue ->
-        issue.message == "Use of struct/2 does not ensure all keys are provided (struct!/2 is preferred)"
+        issue.message ==
+          "Use of struct/2 does not ensure all keys are provided (struct!/2 is preferred)"
       end)
     end
 
@@ -37,7 +38,8 @@ defmodule CivilCredo.Check.Warning.UnsafeStructTest do
       string
       |> to_source_file
       |> assert_issue(@described_check, fn issue ->
-        issue.message == "Use of struct/2 does not ensure all keys are provided (struct!/2 is preferred)"
+        issue.message ==
+          "Use of struct/2 does not ensure all keys are provided (struct!/2 is preferred)"
       end)
     end
 
@@ -106,6 +108,21 @@ defmodule CivilCredo.Check.Warning.UnsafeStructTest do
           def build() do
             struct = :bar
             struct |> foo()
+          end
+        end
+      """
+
+      string
+      |> to_source_file
+      |> refute_issues(@described_check)
+    end
+
+    test "allows 'struct' in an ecto query" do
+      string = """
+        defmodule Foo do
+          def build() do
+            from p in Post,
+              select: struct(p, [:title, :body])
           end
         end
       """

--- a/test/check/warning/unsafe_struct_test.exs
+++ b/test/check/warning/unsafe_struct_test.exs
@@ -22,6 +22,25 @@ defmodule CivilCredo.Check.Warning.UnsafeStructTest do
       end)
     end
 
+    test "finds calls to struct/2 in a pipeline" do
+      string = """
+        defmodule Foo do
+          defstruct :bar
+
+          def build(bar) do
+            __MODULE__
+            |> struct(bar: bar)
+          end
+        end
+      """
+
+      string
+      |> to_source_file
+      |> assert_issue(@described_check, fn issue ->
+        issue.message == "Use of struct/2 does not ensure all keys are provided (struct!/2 is preferred)"
+      end)
+    end
+
     test "allows calls to struct!/2" do
       string = """
         defmodule Foo do
@@ -29,6 +48,64 @@ defmodule CivilCredo.Check.Warning.UnsafeStructTest do
 
           def build(bar) do
             struct!(__MODULE__, bar: bar)
+          end
+        end
+      """
+
+      string
+      |> to_source_file
+      |> refute_issues(@described_check)
+    end
+
+    test "allows 'struct' as a param name" do
+      string = """
+        defmodule Foo do
+          def build(struct) do
+            struct = Map.put(struct, :foo, :bar)
+          end
+        end
+      """
+
+      string
+      |> to_source_file
+      |> refute_issues(@described_check)
+    end
+
+    test "allows 'struct' as a local on the left side of a match" do
+      string = """
+        defmodule Foo do
+          def build() do
+            struct = :bar
+          end
+        end
+      """
+
+      string
+      |> to_source_file
+      |> refute_issues(@described_check)
+    end
+
+    test "allows 'struct' as a parameter in a function call" do
+      string = """
+        defmodule Foo do
+          def build() do
+            struct = :bar
+            foo = baz(struct)
+          end
+        end
+      """
+
+      string
+      |> to_source_file
+      |> refute_issues(@described_check)
+    end
+
+    test "allows 'struct' as a local at the start of a pipeline" do
+      string = """
+        defmodule Foo do
+          def build() do
+            struct = :bar
+            struct |> foo()
           end
         end
       """


### PR DESCRIPTION
Basically, any line with the word `struct` present fails the test. Can we check that we are calling a function?